### PR TITLE
Fix example sbt setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A library for parsing, querying, and ordering the always faithful, always loyal 
 
 Add the following to your sbt build definition
 
-    libraryDependencies += "net.leibman" % "semverfi" % "0.2.0"
+    libraryDependencies += "net.leibman" %% "semverfi" % "0.2.0"
     
 ### the civilized method
 


### PR DESCRIPTION
The example is missing an extra `%` on the module id which causes it to add the Scala version.

Without it you get:
```
error] stack trace is suppressed; run last update for the full output
[error] (update) sbt.librarymanagement.ResolveException: Error downloading net.leibman:semverfi:0.2.0
[error]   Not found
[error]   Not found
[error]   not found: https://repo1.maven.org/maven2/net/leibman/semverfi/0.2.0/semverfi-0.2.0.pom
[error]   not found: /Users/jason/.ivy2/local/net.leibman/semverfi/0.2.0/ivys/ivy.xml
[error]   not found: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/net.leibman/semverfi/0.2.0/ivys/ivy.xml
[error]   not found: https://repo.typesafe.com/typesafe/ivy-releases/net.leibman/semverfi/0.2.0/ivys/ivy.xml
Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore?
```